### PR TITLE
fixed the frame bug while animation in Xcode7-beta6 (iOS9)

### DIFF
--- a/PinterestAnimator/Helpers/NavigationHelper/Transition/XHPinterestPopTransition.m
+++ b/PinterestAnimator/Helpers/NavigationHelper/Transition/XHPinterestPopTransition.m
@@ -18,6 +18,7 @@
     
     UIView *containerView = [transitionContext containerView];
     
+    toViewController.view.frame = fromViewController.view.frame;
     UIView *toView = toViewController.view;
     
     [containerView addSubview:toView];

--- a/PinterestAnimator/Helpers/NavigationHelper/Transition/XHPinterestPushTransition.m
+++ b/PinterestAnimator/Helpers/NavigationHelper/Transition/XHPinterestPushTransition.m
@@ -19,6 +19,7 @@
     UIView *containerView = [transitionContext containerView];
 
     UIView *fromView = fromViewController.view;
+    toViewController.view.frame = fromView.frame;
     UIView *toView = toViewController.view;
     
     UICollectionView *waterFallView = [fromViewController transitionCollectionView];


### PR DESCRIPTION
运行在iOS9上的时候，返回动画的布局有些错乱，在我的项目中，进入的动画也是错乱的，总之原因就是toViewController的frame在iOS9上错乱了，fromViewController的frame是正常的 但是所以我简单调整了一下
